### PR TITLE
Add usernames to "Reply to" in replies

### DIFF
--- a/app/src/husky/res/values-pl/strings.xml
+++ b/app/src/husky/res/values-pl/strings.xml
@@ -74,4 +74,5 @@
     <string name="status_replied_to_format">Odpowiedź dla %s</string>
     <string name="chat_our_last_message"><b>Ty</b></string>
     <string name="pref_title_other">Inne</string>
+    <string name="status_replied_to_and_more_format">i %d więcej.</string>
 </resources>

--- a/app/src/husky/res/values-pl/strings.xml
+++ b/app/src/husky/res/values-pl/strings.xml
@@ -71,8 +71,8 @@
     <string name="attachment_type_audio">Audio</string>
     <string name="attachment_type_unknown">Załącznik</string>
     <string name="link">Odnośnik</string>
-    <string name="status_replied_to_format">Odpowiedź dla %s</string>
+    <string name="status_replied_to_format">Odpowiedź dla @%s</string>
     <string name="chat_our_last_message"><b>Ty</b></string>
     <string name="pref_title_other">Inne</string>
-    <string name="status_replied_to_and_more_format">i %d więcej.</string>
+    <string name="status_replied_to_and_more_format">" i %d więcej."</string>
 </resources>

--- a/app/src/husky/res/values/strings.xml
+++ b/app/src/husky/res/values/strings.xml
@@ -120,6 +120,7 @@
     <string name="status_share_link">Share link to post</string>
     <string name="status_boosted_format">%s repeated</string>
     <string name="status_replied_to_format">Reply to %s</string>
+    <string name="status_replied_to_and_more_format">and %d more.</string>
     
     <string name="title_scheduled_toot">Scheduled posts</string>
     <string name="title_reblogged_by">Repeated by</string>

--- a/app/src/husky/res/values/strings.xml
+++ b/app/src/husky/res/values/strings.xml
@@ -119,8 +119,8 @@
     <string name="status_share_content">Share content of post</string>
     <string name="status_share_link">Share link to post</string>
     <string name="status_boosted_format">%s repeated</string>
-    <string name="status_replied_to_format">Reply to %s</string>
-    <string name="status_replied_to_and_more_format">and %d more.</string>
+    <string name="status_replied_to_format">Reply to @%s</string>
+    <string name="status_replied_to_and_more_format">" and %d more."</string>
     
     <string name="title_scheduled_toot">Scheduled posts</string>
     <string name="title_reblogged_by">Repeated by</string>

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
@@ -714,26 +714,11 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
             contentWarningDescriptionTextView.setText(emojifiedContentWarning);
         }
 
-        private String getReplyToAccountString(Context context, Status.Mention[] mentions){
-            String replyToAccountString = "";
-            String format = context.getString(R.string.status_replied_to_and_more_format);
-            if(mentions != null) {
-                if (mentions.length > 1) {
-                    replyToAccountString = String.format(Locale.getDefault(),"@%s "+format, mentions[0].getLocalUsername(), mentions.length - 1);
-                } else if (mentions.length == 1) {
-                    replyToAccountString = String.format("@%s", mentions[0].getLocalUsername());
-                }
-            }
-            return replyToAccountString;
-        }
-
         private void setupReplyInfo() {
             if (statusViewData.getInReplyToId() != null) {
                 Context context = replyInfo.getContext();
-                String replyToAccount = statusViewData.getInReplyToAccountAcct();
-                Status.Mention[] mentions = statusViewData.getMentions();
-                String replyToString = getReplyToAccountString(context, mentions);
-                replyInfo.setText(context.getString(R.string.status_replied_to_format, replyToAccount+replyToString));
+                String replyToAccount = statusViewData.getReplyToAccountString(context);
+                replyInfo.setText(replyToAccount);
                 if (!statusViewData.getParentVisible()) {
                     replyInfo.setPaintFlags(replyInfo.getPaintFlags() | Paint.STRIKE_THRU_TEXT_FLAG);
                     replyInfo.setOnClickListener(null);

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
@@ -44,6 +44,7 @@ import com.keylesspalace.tusky.R;
 import com.keylesspalace.tusky.entity.Account;
 import com.keylesspalace.tusky.entity.Emoji;
 import com.keylesspalace.tusky.entity.Notification;
+import com.keylesspalace.tusky.entity.Status;
 import com.keylesspalace.tusky.interfaces.AccountActionListener;
 import com.keylesspalace.tusky.interfaces.LinkListener;
 import com.keylesspalace.tusky.interfaces.StatusActionListener;
@@ -713,11 +714,26 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
             contentWarningDescriptionTextView.setText(emojifiedContentWarning);
         }
 
+        private String getReplyToAccountString(Context context, Status.Mention[] mentions){
+            String replyToAccountString = "";
+            String format = context.getString(R.string.status_replied_to_and_more_format);
+            if(mentions != null) {
+                if (mentions.length > 1) {
+                    replyToAccountString = String.format(Locale.getDefault(),"@%s "+format, mentions[0].getLocalUsername(), mentions.length - 1);
+                } else if (mentions.length == 1) {
+                    replyToAccountString = String.format("@%s", mentions[0].getLocalUsername());
+                }
+            }
+            return replyToAccountString;
+        }
+
         private void setupReplyInfo() {
             if (statusViewData.getInReplyToId() != null) {
                 Context context = replyInfo.getContext();
                 String replyToAccount = statusViewData.getInReplyToAccountAcct();
-                replyInfo.setText(context.getString(R.string.status_replied_to_format, replyToAccount));
+                Status.Mention[] mentions = statusViewData.getMentions();
+                String replyToString = getReplyToAccountString(context, mentions);
+                replyInfo.setText(context.getString(R.string.status_replied_to_format, replyToAccount+replyToString));
                 if (!statusViewData.getParentVisible()) {
                     replyInfo.setPaintFlags(replyInfo.getPaintFlags() | Paint.STRIKE_THRU_TEXT_FLAG);
                     replyInfo.setOnClickListener(null);

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -1,6 +1,7 @@
 package com.keylesspalace.tusky.adapter;
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
@@ -382,11 +383,26 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
 
     }
 
+    private String getReplyToAccountString(Context context, Status.Mention[] mentions){
+        String replyToAccountString = "";
+        String format = context.getString(R.string.status_replied_to_and_more_format);
+        if(mentions != null) {
+            if (mentions.length > 1) {
+                replyToAccountString = String.format(Locale.getDefault(),"@%s "+format, mentions[0].getLocalUsername(), mentions.length - 1);
+            } else if (mentions.length == 1) {
+                replyToAccountString = String.format("@%s", mentions[0].getLocalUsername());
+            }
+        }
+        return replyToAccountString;
+    }
+
     protected void setReplyInfo(StatusViewData.Concrete status, StatusActionListener listener) {
         if (status.getInReplyToId() != null) {
             Context context = replyInfo.getContext();
             String replyToAccount = status.getInReplyToAccountAcct();
-            replyInfo.setText(context.getString(R.string.status_replied_to_format, replyToAccount));
+            Status.Mention[] mentions = status.getMentions();
+            String replyToString = getReplyToAccountString(context, mentions);
+            replyInfo.setText(context.getString(R.string.status_replied_to_format, replyToAccount+replyToString));
             if (!status.getParentVisible()) {
                 replyInfo.setPaintFlags(replyInfo.getPaintFlags() | Paint.STRIKE_THRU_TEXT_FLAG);
                 replyInfo.setOnClickListener(null);

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -383,26 +383,11 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
 
     }
 
-    private String getReplyToAccountString(Context context, Status.Mention[] mentions){
-        String replyToAccountString = "";
-        String format = context.getString(R.string.status_replied_to_and_more_format);
-        if(mentions != null) {
-            if (mentions.length > 1) {
-                replyToAccountString = String.format(Locale.getDefault(),"@%s "+format, mentions[0].getLocalUsername(), mentions.length - 1);
-            } else if (mentions.length == 1) {
-                replyToAccountString = String.format("@%s", mentions[0].getLocalUsername());
-            }
-        }
-        return replyToAccountString;
-    }
-
     protected void setReplyInfo(StatusViewData.Concrete status, StatusActionListener listener) {
         if (status.getInReplyToId() != null) {
             Context context = replyInfo.getContext();
-            String replyToAccount = status.getInReplyToAccountAcct();
-            Status.Mention[] mentions = status.getMentions();
-            String replyToString = getReplyToAccountString(context, mentions);
-            replyInfo.setText(context.getString(R.string.status_replied_to_format, replyToAccount+replyToString));
+            String replyToAccount = status.getReplyToAccountString(context);
+            replyInfo.setText(replyToAccount);
             if (!status.getParentVisible()) {
                 replyInfo.setPaintFlags(replyInfo.getPaintFlags() | Paint.STRIKE_THRU_TEXT_FLAG);
                 replyInfo.setOnClickListener(null);

--- a/app/src/main/java/com/keylesspalace/tusky/viewdata/StatusViewData.java
+++ b/app/src/main/java/com/keylesspalace/tusky/viewdata/StatusViewData.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 
 /**
@@ -104,6 +105,18 @@ public abstract class StatusViewData {
         private final List<EmojiReaction> emojiReactions;
         private final boolean parentVisible;
 
+        private String getReplyToAccountString(){
+            String replyToAccountString = "";
+            if(this.mentions != null) {
+                if (this.mentions.length > 1) {
+                    replyToAccountString = String.format(Locale.getDefault(),"@%s and %d more", this.mentions[0].getLocalUsername(), this.mentions.length - 1);
+                } else if (this.mentions.length == 1) {
+                    replyToAccountString = String.format("@%s", this.mentions[0].getLocalUsername());
+                }
+            }
+            return replyToAccountString;
+        }
+
         public Concrete(String id, Spanned content, boolean reblogged, boolean favourited, boolean bookmarked,
                         @Nullable String spoilerText, Status.Visibility visibility, List<Attachment> attachments,
                         @Nullable String rebloggedByUsername, @Nullable String rebloggedAvatar, boolean sensitive, boolean isExpanded,
@@ -141,8 +154,8 @@ public abstract class StatusViewData {
             this.reblogsCount = reblogsCount;
             this.favouritesCount = favouritesCount;
             this.inReplyToId = inReplyToId;
-            this.inReplyToAccountAcct = inReplyToAccountAcct;
             this.mentions = mentions;
+            this.inReplyToAccountAcct = getReplyToAccountString();
             this.senderId = senderId;
             this.rebloggingEnabled = rebloggingEnabled;
             this.application = application;

--- a/app/src/main/java/com/keylesspalace/tusky/viewdata/StatusViewData.java
+++ b/app/src/main/java/com/keylesspalace/tusky/viewdata/StatusViewData.java
@@ -15,12 +15,15 @@
 
 package com.keylesspalace.tusky.viewdata;
 
+import android.content.res.Resources;
 import android.os.Build;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 
 import androidx.annotation.Nullable;
+import androidx.core.content.res.ResourcesCompat;
 
+import com.keylesspalace.tusky.R;
 import com.keylesspalace.tusky.entity.Attachment;
 import com.keylesspalace.tusky.entity.Card;
 import com.keylesspalace.tusky.entity.Emoji;
@@ -105,18 +108,6 @@ public abstract class StatusViewData {
         private final List<EmojiReaction> emojiReactions;
         private final boolean parentVisible;
 
-        private String getReplyToAccountString(){
-            String replyToAccountString = "";
-            if(this.mentions != null) {
-                if (this.mentions.length > 1) {
-                    replyToAccountString = String.format(Locale.getDefault(),"@%s and %d more", this.mentions[0].getLocalUsername(), this.mentions.length - 1);
-                } else if (this.mentions.length == 1) {
-                    replyToAccountString = String.format("@%s", this.mentions[0].getLocalUsername());
-                }
-            }
-            return replyToAccountString;
-        }
-
         public Concrete(String id, Spanned content, boolean reblogged, boolean favourited, boolean bookmarked,
                         @Nullable String spoilerText, Status.Visibility visibility, List<Attachment> attachments,
                         @Nullable String rebloggedByUsername, @Nullable String rebloggedAvatar, boolean sensitive, boolean isExpanded,
@@ -154,8 +145,8 @@ public abstract class StatusViewData {
             this.reblogsCount = reblogsCount;
             this.favouritesCount = favouritesCount;
             this.inReplyToId = inReplyToId;
+            this.inReplyToAccountAcct = inReplyToAccountAcct;
             this.mentions = mentions;
-            this.inReplyToAccountAcct = getReplyToAccountString();
             this.senderId = senderId;
             this.rebloggingEnabled = rebloggingEnabled;
             this.application = application;

--- a/app/src/main/java/com/keylesspalace/tusky/viewdata/StatusViewData.java
+++ b/app/src/main/java/com/keylesspalace/tusky/viewdata/StatusViewData.java
@@ -15,6 +15,7 @@
 
 package com.keylesspalace.tusky.viewdata;
 
+import android.content.Context;
 import android.content.res.Resources;
 import android.os.Build;
 import android.text.SpannableStringBuilder;
@@ -107,6 +108,20 @@ public abstract class StatusViewData {
         @Nullable
         private final List<EmojiReaction> emojiReactions;
         private final boolean parentVisible;
+
+        public String getReplyToAccountString(Context context){
+            String replyToAccountString = "";
+            String replyTo = context.getString(R.string.status_replied_to_format);
+            String format = context.getString(R.string.status_replied_to_and_more_format);
+            if(this.mentions != null) {
+                if (this.mentions.length > 1) {
+                    replyToAccountString = String.format(Locale.getDefault(),replyTo+format, this.mentions[0].getLocalUsername(), this.mentions.length - 1);
+                } else if (this.mentions.length == 1) {
+                    replyToAccountString = String.format(replyTo, this.mentions[0].getLocalUsername());
+                }
+            }
+            return replyToAccountString;
+        }
 
         public Concrete(String id, Spanned content, boolean reblogged, boolean favourited, boolean bookmarked,
                         @Nullable String spoilerText, Status.Visibility visibility, List<Attachment> attachments,


### PR DESCRIPTION
With [recent changes to Soapbox](https://gitlab.com/soapbox-pub/soapbox-fe/-/merge_requests/930) replies from instances that use that FE no longer contain mentions in Status text which may look confusing for non-Soapbox users. Although Husky has "Reply to" functionality in Statuses I thought it would be a nice idea to also display the usernames next to "Reply to".

## Before
![before](https://user-images.githubusercontent.com/97320529/148624133-3aefbe28-1d4d-4219-8083-f077752d338a.png)
 
## After
![after](https://user-images.githubusercontent.com/97320529/148624146-dad20d04-bae5-436f-a2cc-a551685d4d9a.png)

Sorry in advance for the mess in the commits.

